### PR TITLE
Add lychee internal-link check on every PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate internal markdown links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress --offline '**/*.md'
+          fail: true


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `lychee --offline` against every Markdown file in the repo on every pull request and every push to `main`. Offline mode means only internal file and anchor references are validated — no external HTTP requests, no rate-limit flakes — which is exactly the failure mode that matters for a planning repository whose docs cross-reference each other. Once this lands, the `link-check` job can be added to the branch protection ruleset to gate merges and to enable the "Require branches to be up to date before merging" requirement, matching the same CI foundation rolled out across the workspace's other repos.